### PR TITLE
Updated example override docs for def autocomplete_product_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ form elements to get the values:
         brand_id = params[:brand_id]
         country = params[:country]
         products = Product.where('brand = ? AND country = ? AND name LIKE ?', brand_id, country, "%#{term}%").order(:name).all
-        render :json => products.map { |product| {:id => product.id, :label => product.name, :value => product.name} }
+        render :json => products.map { |product| {:id => product.id, :label => product.name, :value => product.name} }, :root => false
       end
     end
 


### PR DESCRIPTION
It was missing :root => false so rendered json included an inferred root ( http://stackoverflow.com/questions/13160551/rails-render-json-1-2-3-behaving-differently-in-production-json-root ) which causes problems with plugin.
